### PR TITLE
Fix: Invitations Not Registering Role ID

### DIFF
--- a/stubs/app/Actions/Teams/InviteTeamMember.php
+++ b/stubs/app/Actions/Teams/InviteTeamMember.php
@@ -34,6 +34,8 @@ class InviteTeamMember implements InvitesTeamMembers
 
         InvitingTeamMember::dispatch($team, $email, $role);
 
+        $role_id = $roleCode ? optional($team->getRole($roleCode))->id : null;
+
         $invitation = $team->invitations()->create(compact('email', 'role'));
 
         Mail::to($email)->send(new Invitation($invitation));


### PR DESCRIPTION
When sending an invitation with a role, the system attempted to create the invitation using the (string) role name instead of the (int) role_id. As a result, invitations with roles were not being properly registered in the database, leaving the role_id column as NULL.

This patch resolves the issue by using the (string) role name to retrieve the corresponding role_id from the team before creating the invitation.