### PR TITLE
Add support for wildcard team permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,32 @@ To ensure that incoming requests initiated by a team member can be executed by t
 return $user->hasTeamPermission($team, 'server:update');
 ```
 
+### Wildcard Permissions
+
+You can choose to enable wildcard permissions in the config. Enabling wildcards will allow you to specify permission node(s) that grants a user all access if they have that permission attached to them.
+```php
+/*
+|--------------------------------------------------------------------------
+| Wildcard Permissions
+|--------------------------------------------------------------------------
+| Configure wildcard permission nodes, allowing you to specify super admin
+| permission node(s) that allows a user to perform all actions on a team.
+*/
+'wildcards' => [
+    'enabled' => false,
+    'nodes' => [
+        '*',
+        '*.*',
+        'all'
+    ]
+]
+```
+
+In the example configuration above, users with the permission nodes of "\*" or "\*.\*" or "all" would be allowed to perform all actions on their team.
+
+> [!NOTE]
+> This configuration does not grant global team access. It only allows you to grant all permissions to a user or role in the team 
+
 Abilities
 -------------------------------------------
 

--- a/config/teams.php
+++ b/config/teams.php
@@ -95,7 +95,7 @@ return [
     | permission node(s) that allows a user to perform all actions on a team.
     */
     'wildcards' => [
-        'enabled' => true,
+        'enabled' => false,
         'nodes' => [
             '*',
             '*.*',

--- a/config/teams.php
+++ b/config/teams.php
@@ -86,4 +86,21 @@ return [
             'middleware' => 'web'
         ]
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wildcard Permissions
+    |--------------------------------------------------------------------------
+    | Configure wildcard permission nodes, allowing you to specify super admin
+    | permission node(s) that allows a user to perform all actions on a team.
+    */
+    'wildcards' => [
+        'enabled' => true,
+        'nodes' => [
+            '*',
+            '*.*',
+            'all'
+        ]
+    ]
+
 ];

--- a/src/Traits/HasTeams.php
+++ b/src/Traits/HasTeams.php
@@ -463,9 +463,19 @@ trait HasTeams
     {
         // Generate all possible wildcards from the permission segments
         $segments = collect(explode('.', $permission));
+
         $codes = $segments->map(function ($item, $key) use ($segments) {
             return $segments->take($key + 1)->implode('.') . ($key + 1 === $segments->count() ? '' : '.*') ;
         });
+
+        // Add in the optional wildcard permissions
+        if(Config::get('teams.wildcards.enabled', false)) {
+            // Build the code collection
+            $wildcardCodes = collect(Config::get('teams.wildcards.nodes', []));
+
+            // Replace codes with the new codes
+            $codes = $wildcardCodes->merge($codes);
+        }
 
         return !empty(array_intersect($codes->all(), $userPermissions));
     }


### PR DESCRIPTION
Introduces a 'wildcards' configuration option in teams.php to enable and define wildcard permission nodes (e.g., '*', '*.*', 'all'). Updates HasTeams trait to check for these wildcard permissions when determining user access.