### PR TITLE
Add request-level permission decision caching

### DIFF
--- a/config/teams.php
+++ b/config/teams.php
@@ -72,6 +72,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Request Lifecycle
+    |--------------------------------------------------------------------------
+    | Configure request lifecycle options
+    */
+    'request' => [
+        // Enabling this option caches the permission decision for the request
+        'cache_decisions' => false,
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
     | Invitations
     |--------------------------------------------------------------------------
     | Configures the team invitation feature, allowing users to be invited to join teams.

--- a/src/Traits/HasTeams.php
+++ b/src/Traits/HasTeams.php
@@ -200,13 +200,17 @@ trait HasTeams
             return $this->determineTeamPermission($team, $permissions, $require, $scope);
         }
 
-        // Create a unique cache key for this request
-        $cacheKey = hash('sha256', serialize([
-            $team->id,
+        // Serialize the data
+        $serializedData = serialize([
+            $this->attributes['id'],
+            $team->attributes['id'],
             $permissions,
             $require,
             $scope
-        ]));
+        ]);
+
+        // Create a unique cache key for this request
+        $cacheKey = hash('sha256', $serializedData);
 
         // Check to see if the cache key exists, if not populate it
         if (!isset($this->decisionCache[$cacheKey])) {
@@ -230,7 +234,7 @@ trait HasTeams
      * @return bool
      * @throws Exception
      */
-    private function determineTeamPermission(object $team, string|array $permissions, bool $require = false, string|null $scope = null): bool
+    protected function determineTeamPermission(object $team, string|array $permissions, bool $require = false, string|null $scope = null): bool
     {
         if ($this->ownsTeam($team)) {
             return true;

--- a/src/Traits/HasTeams.php
+++ b/src/Traits/HasTeams.php
@@ -202,7 +202,7 @@ trait HasTeams
 
         // Serialize the data
         $serializedData = serialize([
-            $this->attributes['id'],
+            $this->attributes[$this->primaryKey],
             $team->attributes['id'],
             $permissions,
             $require,


### PR DESCRIPTION
### Summary
Introduces a 'request.cache_decisions' option to the teams config to enable caching of permission decisions for the duration of a request. Updates HasTeams trait to cache permission checks per request, improving performance when enabled.

### Benchmarking
Benchmarks comparing cached vs uncached decisions. On 100,000 iterations, there is a ~163.15% performance gain on previously made decisions in the same request across 5 permission nodes
```
{
    "iterations": 100000,
    "startingCache": [],
    "cached": 0.004121562679999676,
    "uncached": 0.010848124910000036,
    "decisionCachePerformanceImprovement": 163.20417162746847,
    "endingCache": {
        "6756f3c44926d4d338f27b027d933cd8521b3a9bd2f37345fb12d859b9fd7a5a": false,
        "fa736ea555bdd59200751940effa26af9fbc7f9e63ddbd62cae6f3961c3eb337": false,
        "999c458b118cc60982c7c6dc29d3859535d97e472d46528946efa2398b444add": false,
        "e0436c95f54d4c3f2d81fe70469a70b93334ca365fd14464d29f78979229922b": false,
        "53543c53cf51aeb01f6d4865a1c132f1a14194712be7896f56917d790a96af30": false
    }
}
``` 